### PR TITLE
fix(sample): correct HyperMedia links endpoints

### DIFF
--- a/Erudio.HATEOAS/docs/README.md
+++ b/Erudio.HATEOAS/docs/README.md
@@ -46,40 +46,41 @@ namespace RESTFulSampleServer.HyperMedia.Enricher
         protected override Task EnrichModel(BookVO content, IUrlHelper urlHelper)
         {
             var path = "api/book";
-            string link = GetLink(content.Id, urlHelper, path);
+            string linkWithId = GetLink(content.Id, urlHelper, path);
+            string linkWithoutId = GetLink(null, urlHelper, path);
 
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.GET,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultGet
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.POST,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.PUT,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPut
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.DELETE,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = "int"
             });
             return Task.CompletedTask;
         }
 
-        private string GetLink(long id, IUrlHelper urlHelper, string path)
+        private string GetLink(long? id, IUrlHelper urlHelper, string path)
         {
             lock (this)
             {
@@ -219,13 +220,13 @@ namespace RESTFulSampleServer.Controllers
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/1",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "POST"
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/1",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "PUT"
             },
@@ -252,13 +253,13 @@ namespace RESTFulSampleServer.Controllers
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/2",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "POST"
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/2",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "PUT"
             },
@@ -292,13 +293,13 @@ namespace RESTFulSampleServer.Controllers
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/1</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>POST</Action>
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/1</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>PUT</Action>
             </HyperMediaLink>
@@ -325,13 +326,13 @@ namespace RESTFulSampleServer.Controllers
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/2</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>POST</Action>
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/2</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>PUT</Action>
             </HyperMediaLink>

--- a/README.md
+++ b/README.md
@@ -50,40 +50,41 @@ namespace RESTFulSampleServer.HyperMedia.Enricher
         protected override Task EnrichModel(BookVO content, IUrlHelper urlHelper)
         {
             var path = "api/book";
-            string link = GetLink(content.Id, urlHelper, path);
+            string linkWithId = GetLink(content.Id, urlHelper, path);
+            string linkWithoutId = GetLink(null, urlHelper, path);
 
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.GET,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultGet
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.POST,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.PUT,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPut
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.DELETE,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = "int"
             });
             return Task.CompletedTask;
         }
 
-        private string GetLink(long id, IUrlHelper urlHelper, string path)
+        private string GetLink(long? id, IUrlHelper urlHelper, string path)
         {
             lock (this)
             {
@@ -223,13 +224,13 @@ namespace RESTFulSampleServer.Controllers
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/1",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "POST"
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/1",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "PUT"
             },
@@ -256,13 +257,13 @@ namespace RESTFulSampleServer.Controllers
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/2",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "POST"
             },
             {
                 "rel": "self",
-                "href": "https://localhost:44300/api/book/v1/2",
+                "href": "https://localhost:44300/api/book/v1",
                 "type": "application/json",
                 "action": "PUT"
             },
@@ -296,13 +297,13 @@ namespace RESTFulSampleServer.Controllers
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/1</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>POST</Action>
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/1</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>PUT</Action>
             </HyperMediaLink>
@@ -329,13 +330,13 @@ namespace RESTFulSampleServer.Controllers
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/2</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>POST</Action>
             </HyperMediaLink>
             <HyperMediaLink>
                 <Rel>self</Rel>
-                <Href>https://localhost:44300/api/book/v1/2</Href>
+                <Href>https://localhost:44300/api/book/v1</Href>
                 <Type>application/json</Type>
                 <Action>PUT</Action>
             </HyperMediaLink>

--- a/sample-project/RestWithASPNETErudio/RestWithASPNETErudio/Hypermedia/Enricher/BookEnricher.cs
+++ b/sample-project/RestWithASPNETErudio/RestWithASPNETErudio/Hypermedia/Enricher/BookEnricher.cs
@@ -10,40 +10,41 @@ namespace Erudio.HATEOAS.Hypermedia.Enricher
         protected override Task EnrichModel(BookVO content, IUrlHelper urlHelper)
         {
             var path = "api/book";
-            string link = GetLink(content.Id, urlHelper, path);
+            string linkWithId = GetLink(content.Id, urlHelper, path);
+            string linkWithoutId = GetLink(null, urlHelper, path);
 
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.GET,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultGet
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.POST,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.PUT,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPut
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.DELETE,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = "int"
             });
             return Task.CompletedTask;
         }
 
-        private string GetLink(long id, IUrlHelper urlHelper, string path)
+        private string GetLink(long? id, IUrlHelper urlHelper, string path)
         {
             lock (this)
             {

--- a/sample-project/RestWithASPNETErudio/RestWithASPNETErudio/Hypermedia/Enricher/PersonEnricher.cs
+++ b/sample-project/RestWithASPNETErudio/RestWithASPNETErudio/Hypermedia/Enricher/PersonEnricher.cs
@@ -10,40 +10,41 @@ namespace Erudio.HATEOAS.Hypermedia.Enricher
         protected override Task EnrichModel(PersonVO content, IUrlHelper urlHelper)
         {
             var path = "api/person";
-            string link = GetLink(content.Id, urlHelper, path);
+            string linkWithId = GetLink(content.Id, urlHelper, path);
+            string linkWithoutId = GetLink(null, urlHelper, path);
 
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.GET,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultGet
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.POST,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.PUT,
-                Href = link,
+                Href = linkWithoutId,
                 Rel = RelationType.self,
                 Type = ResponseTypeFormat.DefaultPut
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.DELETE,
-                Href = link,
+                Href = linkWithId,
                 Rel = RelationType.self,
                 Type = "int"
             });
             return Task.CompletedTask;
         }
 
-        private string GetLink(long id, IUrlHelper urlHelper, string path)
+        private string GetLink(long? id, IUrlHelper urlHelper, string path)
         {
             lock (this)
             {


### PR DESCRIPTION
Makes `id` parameter optional in `GetLink` function in order to have two different **Href** variables so the API can provide the correct links.

`linkWithId` is used in **GET** and **DELETE** links and `linkWithoutId` is used in **POST** and **PUT** links.

Docs updated.